### PR TITLE
Introducing vulnerabilities for the DevSecOps workshop per lab exercises

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ RUN cd /src && go build -o myapp
 
 # iron/go is the alpine image with only ca-certificates added
 FROM alpine
+
+# Following two lines added to introduce vulnerabilities. Comment out to remove vulnerabilities.
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.1/main' >> /etc/apk/repositories
+RUN apk add "openssh==6.7_p1-r6"
+
 RUN apk add openssh 
 WORKDIR /app
 COPY --from=build-env /src/myapp /app/


### PR DESCRIPTION
With this addition, the image is otherwise clean. That's not very interesting for this workshop, and it breaks the security scanning with Codefresh lab at the end of this workshop which expects to first find and then remove vulnerabilities.